### PR TITLE
fix title for "volume prune" in TOC

### DIFF
--- a/_data/toc.yaml
+++ b/_data/toc.yaml
@@ -728,7 +728,7 @@ toc:
       - path: /engine/reference/commandline/volume_ls/
         title: docker volume ls
       - path: /engine/reference/commandline/volume_prune/
-        title: docker volume ls
+        title: docker volume prune
       - path: /engine/reference/commandline/volume_rm/
         title: docker volume rm
     - path: /engine/reference/commandline/wait/


### PR DESCRIPTION
<!--Thanks for your contribution. See [CONTRIBUTING](CONTRIBUTING.md)
    for this project's contribution guidelines. Remove these comments
    as you go.

    DO NOT edit files and directories listed in _data/not_edited_here.yaml.
    These are maintained in upstream repos and changes here will be lost.

    Help us merge your changes more quickly by adding details and setting metadata
    (such as labels, milestones, and reviewers) over at the right-hand side.-->

### Proposed changes

Fixed incorrect title for "volume prune" in table of contents. Was listed as "volume ls", like this:

<img width="241" alt="image" src="https://cloud.githubusercontent.com/assets/11357370/22629582/a1c4bf2c-ebb6-11e6-8aca-0b9d57457e06.png">

